### PR TITLE
add monitoring when idle

### DIFF
--- a/Marlin/src/lcd/extui/lib/mks_ui/draw_ready_print.cpp
+++ b/Marlin/src/lcd/extui/lib/mks_ui/draw_ready_print.cpp
@@ -44,6 +44,14 @@
 
 extern lv_group_t*  g;
 static lv_obj_t *scr;
+static lv_obj_t *labelExt1, *labelFan;
+
+TERN_(HAS_MULTI_EXTRUDER, static lv_obj_t *labelExt2);
+
+#if HAS_HEATED_BED
+  static lv_obj_t* labelBed;
+#endif
+
 #if ENABLED(MKS_TEST)
   uint8_t curent_disp_ui = 0;
 #endif
@@ -174,9 +182,76 @@ void lv_draw_ready_print() {
 
   }
   else {
-    lv_big_button_create(scr, "F:/bmp_tool.bin", main_menu.tool, 20, 90, event_handler, ID_TOOL);
-    lv_big_button_create(scr, "F:/bmp_set.bin", main_menu.set, 180, 90, event_handler, ID_SET);
-    lv_big_button_create(scr, "F:/bmp_printing.bin", main_menu.print, 340, 90, event_handler, ID_PRINT);
+    lv_big_button_create(scr, "F:/bmp_tool.bin", main_menu.tool, 20, 180, event_handler, ID_TOOL);
+    lv_big_button_create(scr, "F:/bmp_set.bin", main_menu.set, 180, 180, event_handler, ID_SET);
+    lv_big_button_create(scr, "F:/bmp_printing.bin", main_menu.print, 340, 180, event_handler, ID_PRINT);
+    
+    // Monitoring
+    #if 1
+      lv_obj_t *buttonExt1 = lv_img_create(scr, NULL);
+      #if HAS_MULTI_EXTRUDER
+        lv_obj_t *buttonExt2 = lv_img_create(scr, NULL);
+      #endif
+      #if HAS_HEATED_BED
+        lv_obj_t *buttonBedstate = lv_img_create(scr, NULL);
+      #endif
+      lv_obj_t *buttonFanstate = lv_img_create(scr, NULL);
+
+      lv_img_set_src(buttonExt1, "F:/bmp_ext1_state.bin");
+      #if HAS_MULTI_EXTRUDER
+        lv_img_set_src(buttonExt2, "F:/bmp_ext2_state.bin");
+      #endif
+      #if HAS_HEATED_BED
+        lv_img_set_src(buttonBedstate, "F:/bmp_bed_state.bin");
+      #endif
+
+      lv_img_set_src(buttonFanstate, "F:/bmp_fan_state.bin");
+
+      lv_obj_set_pos(buttonExt1, 45, 20);
+
+      #if HAS_MULTI_EXTRUDER
+        lv_obj_set_pos(buttonExt2, 45, 120);
+      #endif
+
+      #if HAS_HEATED_BED
+        lv_obj_set_pos(buttonBedstate, 210, 20);
+      #endif
+
+      lv_obj_set_pos(buttonFanstate, 380, 20);
+
+
+      labelExt1 = lv_label_create(scr, 45, 80, nullptr);
+
+      #if HAS_MULTI_EXTRUDER
+        labelExt2 = lv_label_create(scr, 45, 180, nullptr);
+      #endif
+
+      #if HAS_HEATED_BED
+        labelBed = lv_label_create(scr, 210, 80, nullptr);
+      #endif
+
+      labelFan = lv_label_create(scr, 380, 80, nullptr);    
+
+      sprintf_P(buf, PSTR("%d°"), (int)thermalManager.temp_hotend[0].celsius);
+      lv_label_set_text(labelExt1, buf);
+      lv_obj_align(labelExt1, buttonExt1, LV_ALIGN_CENTER, 0, 60);
+      #if HAS_MULTI_EXTRUDER
+        sprintf_P(buf, PSTR("%d°"), (int)thermalManager.temp_hotend[0].celsius);
+        lv_label_set_text(labelExt2, buf);
+        lv_obj_align(labelExt2, buttonExt2, LV_ALIGN_CENTER, 0, 60);
+      #endif
+      
+      #if HAS_HEATED_BED
+        sprintf_P(buf, PSTR("%d°"), (int)thermalManager.temp_bed.celsius);
+        lv_label_set_text(labelBed, buf);
+        lv_obj_align(labelBed, buttonBedstate, LV_ALIGN_CENTER, 0, 60);
+      #endif
+
+      sprintf_P(buf, PSTR("%d%%"), thermalManager.fanPercent(thermalManager.fan_speed[0]));
+      lv_label_set_text(labelFan, buf);
+      lv_obj_align(labelFan, buttonFanstate, LV_ALIGN_CENTER, 0, 60);
+      
+    #endif // if 1
   }
 
   #if ENABLED(TOUCH_SCREEN_CALIBRATION)


### PR DESCRIPTION
### Requirements

* Filling out this template is required. Pull Requests without a clear description may be closed at the maintainers' discretion.

### Description

Add monitoring when idle: icons and labels for extruder temp, bed temp, fan speed. Move existing buttons down a bit.

### Benefits

Ability to monitor printer state when not printing

### Configurations

<!-- Attach any Configuration.h, Configuration_adv.h, or platformio.ini files needed to compile/test your Pull Request. -->

### Related Issues

<!-- Whether this fixes a bug or fulfills a feature request, please list any related Issues here. -->
